### PR TITLE
Restores _trigger arguments

### DIFF
--- a/src/typeahead/event_bus.js
+++ b/src/typeahead/event_bus.js
@@ -44,9 +44,9 @@ var EventBus = (function() {
       var $e;
 
       $e = $.Event(namespace + type);
-      (args = args || []).unshift($e);
+      args = args || [];
 
-      this.$el.trigger.apply(this.$el, args);
+      this.$el.trigger($e, args);
 
       return $e;
     },


### PR DESCRIPTION
[jQuery.trigger](http://api.jquery.com/trigger/) method has the footprint

``` js
.trigger(event [, extraParameters]);
```

where `event` can be a string or an Event object, and `extraParameters` is expected to be _an Array or Plain Object_. You don't need to use `Function.prototype.apply()` since it will unwrap the argument array before passing them to `$element.trigger`

Calling 

``` js
$element.trigger.apply($element, [$event, arg1, arg2, arg3])
```

is equivalent of calling

``` js
$element.trigger($event1, arg1, arg2, arg3);
```

Which means that only arg1 will be taken as `extraParams` while the rest is just discarded.
